### PR TITLE
ZGW-3403: Support single temporal associations

### DIFF
--- a/contiki/platform/linux/parse_config.c
+++ b/contiki/platform/linux/parse_config.c
@@ -421,8 +421,20 @@ void ConfigInit()
     } else {
       cfg.is_max_lr_powerlevel_set = 0;
     }
+
+    cfg.single_classic_temp_association = atoi(
+      config_get_val("ZipAssociationLimit", "0"));
+
+    if ((0 != cfg.single_classic_temp_association) &&
+      (1 != cfg.single_classic_temp_association)) {
+      WRN_PRINTF("Wrong configuration value for "
+                 "\"ZipAssociationLimit\" (%d). Ignoring",
+                 cfg.single_classic_temp_association);
+
+      cfg.single_classic_temp_association = 0;
+    }
   }
- 
+
   /*We wan't command line to override config file.*/
   parse_prog_args();
 }

--- a/files/scripts/config
+++ b/files/scripts/config
@@ -12,6 +12,7 @@ db_input critical zipgateway/zip_lan_ip6 || true
 db_input critical zipgateway/zip_pan_ip6 || true
 db_input critical zipgateway/enable_wlan || true 
 db_input critical zipgateway/bridge_stp || true
+db_input critical zipgateway/association_limit || true
 db_endblock
 if ! db_go ; then
     exit 10

--- a/files/scripts/postinst
+++ b/files/scripts/postinst
@@ -179,6 +179,11 @@ iface br-lan inet dhcp
 
 fi
 
+value=0
+db_input zipgateway/association_limit || true
+[ "Disabled" = "$RET" ] || value=1
+echo ZipAssociationLimit=$value >> $GW_CONFFILE
+
 db_get zipgateway/restart_nw
 if [ "$RET" = "Yes" ]
 then

--- a/files/scripts/templates
+++ b/files/scripts/templates
@@ -43,6 +43,12 @@ Default: Enabled
 Choices: Enabled, Disabled
 Description: Spanning Tree Protocol to bridge to allow multiple bridges
 
+Template: zipgateway/association_limit
+Type: select
+Default: Disabled
+Choices: Enabled, Disabled
+Description: Limit to a single classical temporal association (experimental)
+
 Template: zipgateway/restart_nw
 Type: select 
 Choices: Yes, I will reboot later

--- a/src/Bridge_temp_assoc.c
+++ b/src/Bridge_temp_assoc.c
@@ -390,7 +390,12 @@ temp_assoc_add_to_association_table(temp_association_t *new_a)
 
 static bool check_available_temp_assoc()
 {
-  uint8_t temp_assoc_count = list_length(temp_association_table);
+  uint8_t classic_temp_associations =  MAX_CLASSIC_TEMP_ASSOCIATIONS;
+
+  if (0 != cfg.single_classic_temp_association)
+  {
+    classic_temp_associations = 1;
+  }
 
   if (is_lr_node(nodeOfIP(&(BACKUP_UIP_IP_BUF->destipaddr))) &&
       (lr_temp_assoc_next_nodeid_idx < MAX_LR_TEMP_ASSOCIATIONS))
@@ -401,7 +406,7 @@ static bool check_available_temp_assoc()
     return true;
   }
   else if (is_classic_node(nodeOfIP(&(BACKUP_UIP_IP_BUF->destipaddr))) &&
-             (temp_assoc_next_nodeid_idx < MAX_CLASSIC_TEMP_ASSOCIATIONS))
+             (temp_assoc_next_nodeid_idx < classic_temp_associations))
   {
     DBG_PRINTF("%d classic temp associations are currently allocated (leaving %d unallocated)\n",
                temp_assoc_next_nodeid_idx + 1,

--- a/src/zip_router_config.h
+++ b/src/zip_router_config.h
@@ -305,7 +305,18 @@ struct router_config {
    *  sets the LBT Threshold anytime ZIPGW resets the Z-Wave chip. 
    *  ZW_SetListenBeforeTalkThreshold()
    */
-  uint8_t zw_lbt; 
+  uint8_t zw_lbt;
+
+  /** Configuration parameter single_classic_temp_association in zipgateway.cfg
+   *
+   * Allows to limit to a single classical temporal association. By default, the
+   * Z/IP Gateway uses four classical temporal associations. If the parameter
+   * `single_classic_temp_association` is set, the Z/IP Gateway will use
+   * only one classical temporal associations.
+   * Allowed values are 1=enable or 0=disable (default).
+   * This is an experimental feature.
+   */
+  uint8_t single_classic_temp_association;
 };
 
 /**


### PR DESCRIPTION
Multiple temporal associations may break the communication with end devices that have a single SPAN entry. This is the case for some S500 devices. Because of the use of multiple temporal associations, the Z/IP Gateway can communicate with the same end device using different SPANs. As a consequence, end devices have to store multiple SPANs to communicate with the Z/IP Gateway: one for persistent associations and one for temporal associations. In the case of end devices with the capacity to store only one SPAN, they will have to refresh the SPAN whenever the Z/IP Gateway switches to a different temporal association. If the SPAN changes in between two frame transmissions, then the end device will not be able to use the correct SPAN and will not decrypt the frames.

When using a single temporal association, the Z/IP Gateway will communicate using the same SPAN. Therefore, end devices are not required to track distinct SPANs for the same controller.

The default behavior remains the same, i.e., use four temporal associations. The use of a single temporal association is optional and has to be activated in the configuration file. Since the Z/IP Gateway is in "maintenance mode," and to minimize the impact on current users, it was decided to add this configuration parameter.

Note that this change does not affect Z-Wave LR, where the Z/IP Gateway continues using four temporal associations.