### PR TITLE
ZGW-3429: build: Refactor before integrating libclient

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,6 @@ set(ZGW_SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 set(LIBS2 "${CMAKE_CURRENT_SOURCE_DIR}/libs2" )
 
 set(S2_LIBRARIES s2_controller s2crypto aes)
-include_directories(.)
 
 add_subdirectory( sqlite )
 add_subdirectory( libs2 )
@@ -158,20 +157,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/files/zgw_recover.sh.in ${CMAKE_CURRE
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/files/zgw_backup.sh.in ${CMAKE_CURRENT_BINARY_DIR}/files/zgw_backup.sh @ONLY)
 
 set(CONTIKI contiki )
-
-include_directories(
-${LibUSB_INCLUDE_DIRS}
-${TS2_INCLUDE_DIRS}
-${ZWAVE_INCLUDE_DIR}
-src/serialapi
-src-gen
-src/zwpgrmr
-src/transport
-src/utls
-src/zgw_backup
-src
-.
-)
 
 add_definitions(  -DSERIAL_LOG -DSUPPORTS_MDNS
 -DSECURITY_SUPPORT -DCONTROLLER_CHANGE_SUPPORT -D__ROUTER_VERSION__

--- a/contiki/CMakeLists.txt
+++ b/contiki/CMakeLists.txt
@@ -52,7 +52,14 @@ set(CONTIKI_SRC
 )
 add_library(contiki-core ${CONTIKI_CORE_SRC} )
 
-target_include_directories(contiki-core PUBLIC ${CONTIKI_INC})
+target_include_directories(contiki-core PUBLIC
+  ${CONTIKI_INC}
+  ..
+  ../Z-Wave/include
+  ../src
+  ../src/transport
+  ../src/utls
+)
 
 # Add the ZGW-specific stuff to the basic contiki stuff
 target_compile_definitions(contiki-core
@@ -77,8 +84,12 @@ if (NOT ANDROID)
   add_library(
     contiki-main
     platform/linux/contiki-main.c
-)
-    target_include_directories(contiki-main PUBLIC ${CONTIKI_INC})
+  )
+  target_include_directories(contiki-main PUBLIC
+    ${CONTIKI_INC}
+    ..
+    ../src
+  )
     target_compile_definitions(contiki-main PUBLIC -DPROJECT_CONF_H=\"project-conf.h\" -DCONTIKI_TARGET_LINUX -DUIP_CONF_IPV6=1 -DAUTOSTART_ENABLE )
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,6 +118,7 @@ else()
 
     add_library(zipgateway-lib ${GW_SRC})
     target_include_directories(zipgateway-lib PUBLIC 
+      ${LibUSB_INCLUDE_DIRS}
       ${CMAKE_CURRENT_BINARY_DIR} 
       ${TS2_INCLUDE_DIRS}
       ${ZWAVE_INCLUDE_DIR}
@@ -128,6 +129,7 @@ else()
       utls
       ${CMAKE_SOURCE_DIR}
       ${CMAKE_SOURCE_DIR}/src
+      ..
       )
     target_link_libraries(zipgateway-lib PUBLIC ZWaveAnalyzer contiki  ${S2_LIBRARIES} OpenSSL::SSL OpenSSL::Crypto ${LibUSB_LIBRARIES} 
     sqlite3)

--- a/src/analyzer/CMakeLists.txt
+++ b/src/analyzer/CMakeLists.txt
@@ -15,4 +15,8 @@ add_custom_command( OUTPUT get_list.c
 # include_directories(../../contiki/core ../../contiki/platform/linux)
 
 add_library( ZWaveAnalyzer command_class_validator.c get_list.c CommandAnalyzer.c )
-target_include_directories( ZWaveAnalyzer PUBLIC . )
+target_include_directories( ZWaveAnalyzer
+  PUBLIC
+  .
+  ../../Z-Wave/include
+)

--- a/systools/udprelay/CMakeLists.txt
+++ b/systools/udprelay/CMakeLists.txt
@@ -7,10 +7,14 @@ ExternalProject_Add(
 
 add_definitions( -D_GNU_SOURCE )
 
-include_directories( ${CMAKE_BINARY_DIR}/stage/include )
 link_directories( ${CMAKE_BINARY_DIR}/stage/lib )
 
 add_executable( udprelay udprelay.c)
+
+target_include_directories(udprelay
+  PUBLIC
+  ${CMAKE_BINARY_DIR}/stage/include
+)
 target_link_libraries( udprelay libpcap.a )
 add_dependencies(udprelay libpcap)
 

--- a/systools/zw_programmer/CMakeLists.txt
+++ b/systools/zw_programmer/CMakeLists.txt
@@ -1,8 +1,30 @@
 find_package(LibUSB 1.0)
 
+add_executable(zw_programmer
+  zw_programmer.c
+# Other sources from the ZIP Gateway without any modification
+  ${CMAKE_SOURCE_DIR}/src/txmodem.c
+  ${CMAKE_SOURCE_DIR}/src/serialapi/port-timer-linux.c
+  ${CONTIKI_DIR}/cpu/native/linux-serial.c
+  ${CONTIKI_DIR}/core/lib/assert.c
+  ${CMAKE_SOURCE_DIR}/src/serialapi/Serialapi.c
+  ${CMAKE_SOURCE_DIR}/src/serialapi/conhandle.c
+  ${CMAKE_SOURCE_DIR}/src/serialapi/nvm_tools.c
+  ${CMAKE_SOURCE_DIR}/src/serialapi/sdk_versioning.c
+  ${CMAKE_SOURCE_DIR}/src/zwpgrmr/zpg.c
+  ${CMAKE_SOURCE_DIR}/src/zwpgrmr/zpgp.c
+  ${CMAKE_SOURCE_DIR}/src/zwpgrmr/linux_usb_interface.c
+  ${CMAKE_SOURCE_DIR}/src/zwpgrmr/linux_serial_interface.c
+  ${CMAKE_SOURCE_DIR}/src/zwpgrmr/crc32.c
+  ${CMAKE_SOURCE_DIR}/src/utls/zgw_crc.c
+  ${CMAKE_SOURCE_DIR}/src/utls/zgw_nodemask.c
+  ${CMAKE_SOURCE_DIR}/src/utls/hex_to_bin.c
+)
 
-include_directories(
-	.
+target_include_directories(
+  zw_programmer
+  PUBLIC
+  ../..
 	# Include paths from the ZIP Gateway
 	${CMAKE_SOURCE_DIR}/Z-Wave/include
 	${CMAKE_SOURCE_DIR}/src
@@ -23,26 +45,6 @@ include_directories(
   ${LibUSB_INCLUDE_DIRS}
 )
 
-add_executable(zw_programmer
-	zw_programmer.c
-	# Other sources from the ZIP Gateway without any modification
-	${CMAKE_SOURCE_DIR}/src/txmodem.c
-	${CMAKE_SOURCE_DIR}/src/serialapi/port-timer-linux.c
-	${CONTIKI_DIR}/cpu/native/linux-serial.c
-	${CONTIKI_DIR}/core/lib/assert.c
-	${CMAKE_SOURCE_DIR}/src/serialapi/Serialapi.c
-  ${CMAKE_SOURCE_DIR}/src/serialapi/conhandle.c
-  ${CMAKE_SOURCE_DIR}/src/serialapi/nvm_tools.c
-	${CMAKE_SOURCE_DIR}/src/serialapi/sdk_versioning.c
-	${CMAKE_SOURCE_DIR}/src/zwpgrmr/zpg.c
-	${CMAKE_SOURCE_DIR}/src/zwpgrmr/zpgp.c
-	${CMAKE_SOURCE_DIR}/src/zwpgrmr/linux_usb_interface.c
-	${CMAKE_SOURCE_DIR}/src/zwpgrmr/linux_serial_interface.c
-	${CMAKE_SOURCE_DIR}/src/zwpgrmr/crc32.c
-	${CMAKE_SOURCE_DIR}/src/utls/zgw_crc.c
-	${CMAKE_SOURCE_DIR}/src/utls/zgw_nodemask.c
-	${CMAKE_SOURCE_DIR}/src/utls/hex_to_bin.c
-)
 
 target_link_libraries(zw_programmer ${LibUSB_LIBRARIES})
 if( NOT APPLE )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_HELPERS
 add_definitions(-DUIP_CONF_IPV6=1 -DAUTOSTART_ENABLE -DUIP_CONF_ROUTER=1 -DZIPGW_UNITTEST -DPROJECT_CONF_H=\"project-conf.h\")
 
 include_directories(
+  ..
   ${CMAKE_SOURCE_DIR}/systools/zgw_eeprom_to_sqlite
   ${CMAKE_SOURCE_DIR}/src/
   ${CMAKE_SOURCE_DIR}/src/serialapi

--- a/test/contiki/CMakeLists.txt
+++ b/test/contiki/CMakeLists.txt
@@ -65,7 +65,7 @@ target_include_directories(zipgateway-contiki-test PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}
   ${LibUSB_INCLUDE_DIRS}
   ${TS2_INCLUDE_DIRS}
-  ${ZWAVE_INCLUDE_DIR}
+  ../../Z-Wave/include
   serialapi
   ${CMAKE_SOURCE_DIR}/src-gen
   zwpgrmr

--- a/test/multicast_tlv/CMakeLists.txt
+++ b/test/multicast_tlv/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_definitions( -DTEST_MULTICAST_TX)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-undef -ggdb")
 
-include_directories(${CMAKE_SOURCE_DIR}/contiki/core/sys  ${CMAKE_SOURCE_DIR}/Z-Wave/include
-${CMAKE_SOURCE_DIR}/contiki/cpu/native ${CMAKE_SOURCE_DIR}/src/ ${CMAKE_SOURCE_DIR}/test)
-
 add_executable(test_multicast_tlv
   ${CMAKE_SOURCE_DIR}/test/multicast_tlv/test_multicast_tlv.c
   ${CMAKE_SOURCE_DIR}/src/multicast_tlv.c
@@ -11,6 +8,15 @@ add_executable(test_multicast_tlv
   ${CMAKE_SOURCE_DIR}/test/test_helpers.c
   ${CMAKE_SOURCE_DIR}/test/test_gw_helpers.c
   ${CMAKE_SOURCE_DIR}/contiki/core/lib/assert.c
+)
+
+target_include_directories(test_multicast_tlv
+  PUBLIC
+  ${CMAKE_SOURCE_DIR}/contiki/core/sys
+  ${CMAKE_SOURCE_DIR}/Z-Wave/include
+  ${CMAKE_SOURCE_DIR}/contiki/cpu/native
+  ${CMAKE_SOURCE_DIR}/src
+  ${CMAKE_SOURCE_DIR}/test
 )
 
 add_test(multicast_tlv test_multicast_tlv)


### PR DESCRIPTION
Avoid propagation of include path to prevent collisions

Note: This change will be built later,
as it requieres some refactoring in other components.

Bug-SiliconLabs: ZGW-3429
Forwarded: https://github.com/SiliconLabs/zipgateway/pulls?q=author%3Arzr