### PR TITLE
ZGW-3429: libzwaveip: build: Warn if mdns deps not satisfied

### DIFF
--- a/libzwaveip/libzwaveip/CMakeLists.txt
+++ b/libzwaveip/libzwaveip/CMakeLists.txt
@@ -2,6 +2,8 @@ if(AVAHI_LIBRARY-CLIENT)
     set(MDNS_SOURCES "avahi-mdns.c")
 elseif(APPLE)
     set(MDNS_SOURCES "dnssd-mdns.c")
+else()
+    message(WARNING "To use the list command, MDNS support is mandatory")
 endif()
 
 add_library(zwaveip ${MDNS_SOURCES} libzwaveip.c zconnection.c network_management.c node_provisioning_list.c zresource.c libzw_log.c ssldbg_utils.c)


### PR DESCRIPTION
I observed that if not build with avahi,
list command do not answer anything