### PR TITLE
ZGW-3424: build: Add path for generated pkgconfig for libs2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ set(CONTIKI_DIR ${CMAKE_CURRENT_SOURCE_DIR}/contiki)
 set(ZGW_SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 
 # Include lib S2
+include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 set(LIBS2 "${CMAKE_CURRENT_SOURCE_DIR}/libs2" )
 
 set(S2_LIBRARIES s2_controller s2crypto aes)


### PR DESCRIPTION
ZGW-3424: build: Add path for generated pkgconfig for libs2
    
When libs2 is a submodule (for public repo it is code dropped until it is maintained in public) it can't be updated with previous patch (see links)
    
This change is not really helpful here,
impact is low but it help to align other tree.
    
Relate-to: https://github.com/SiliconLabs/zipgateway/commit/ee22272804394e88d0e13a7eda5de92e6a5ff44b#r145562119
Relate-to: https://github.com/SiliconLabs/zipgateway/pull/24
Bug-SiliconLabs: ZGW-3424
Origin: https://github.com/SiliconLabs/zipgateway/pull/29
