### PR TITLE
ZGW-3441: serialapi: Harden SerialAPI_AES128_Encrypt use of rijndael alg

### DIFF
--- a/src/serialapi/Serialapi.c
+++ b/src/serialapi/Serialapi.c
@@ -3475,6 +3475,12 @@ BOOL ZW_IsPrimaryCtrl (void) {
 BOOL SerialAPI_AES128_Encrypt(const BYTE *ext_input, BYTE *ext_output, const BYTE *cipherKey) CC_REENTRANT_ARG{
   int Nr; /* key-length-dependent number of rounds */
   u32 rk[4*(MAXNR + 1)]; /* key schedule */
+
+  if (ext_input == NULL || ext_output == NULL || cipherKey == NULL) {
+    ASSERT(0); // Invalid input params
+    return 0;
+  }
+
   /*if(SupportsCommand(FUNC_ID_ZW_AES_ECB)) {
     memcpy(&buffer[0],cipherKey,16);
     memcpy(&buffer[16],ext_input,16);
@@ -3483,6 +3489,10 @@ BOOL SerialAPI_AES128_Encrypt(const BYTE *ext_input, BYTE *ext_output, const BYT
     return 1;
   } else*/ {
     Nr = rijndaelKeySetupEnc(rk, cipherKey, 128);
+    if (Nr <= 0) {
+      ASSERT(0); // Key setup failed
+      return 0;
+    }
     rijndaelEncrypt(rk, Nr, ext_input, ext_output);
     return 1;
   }


### PR DESCRIPTION
This mitigates a bit use of invalid input data.

Also note rijndaelEncrypt is not returning an 1error on wrong arguments, this is prone to misuse or malicious attacks.

After more investigations in zipgwateway it looks like "rijndael-alg-fst.c" was a copy of "Optimised C code v3.0" (under public domain).

I also note that upstream stated that:

IMPORTANT NOTE ! This code was written in order to clarify the mathematical description, and to run the statistical test. Without modification, it should not be used to encrypt files, or for any other application.

And the downstream changes over that code are minimal.

So we can assume the absent check were done on purpose, since it is the fast version of the original "Reference code in ANSI C v2.2".

Please refer to related context.

Bug-SiliconLabs: ZGW-3441
Relate-to: j.s.c/b/UIC-3660
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pull/95
Relate-to: c.s.c/x/MbQ4Jg
Relate-to: SLVDBBP-3113159