### PR TITLE
Fix ZGW-3423: Segmentation fault after clearing the NVM of ZWave NCP Serial API Controller

### DIFF
--- a/src/RD_internal.c
+++ b/src/RD_internal.c
@@ -163,7 +163,13 @@ void rd_node_entry_free(nodeid_t nodeid)
 
 rd_node_database_entry_t* rd_node_get_raw(nodeid_t nodeid)
 {
-   return ndb[nodeid - 1];
+  // Add defensive programming to ensure nodeid is within bounds
+  // Fix ZGW-3423: Segmentation fault if SAPI controller NVM cleared
+  if (nodeid < 1 || nodeid > ZW_MAX_NODES) {
+    ERR_PRINTF("Invalid nodeid(%d) out of array range!\n", nodeid);
+    return NULL; // Return NULL if nodeid is out of bounds
+  }
+  return ndb[nodeid - 1];
 }
 
 

--- a/src/ResourceDirectory.c
+++ b/src/ResourceDirectory.c
@@ -1438,12 +1438,12 @@ void send_suc_id(uint8_t status)
     if (status!= TRANSMIT_COMPLETE_OK) {
       ERR_PRINTF("ERROR: ZW_SendSUCID or ZW_AssignSUCReturnRoute to node id: %d failed\n", current_send_suc_id_dest);
     }
-    while (current_send_suc_id_dest <= ZW_MAX_NODES)
+    while (current_send_suc_id_dest < ZW_MAX_NODES)
     {
        current_send_suc_id_dest++;
        if (current_send_suc_id_dest == MyNodeID)
          continue;
-
+         
        nd = rd_node_get_raw(current_send_suc_id_dest);
        if (!nd)
          continue;

--- a/test/mock_rd.c
+++ b/test/mock_rd.c
@@ -3,12 +3,19 @@
 #include "ResourceDirectory.h"
 #include "RD_types.h"
 #include <stdlib.h>
+#include <assert.h>
+#include <ZIP_Router_logging.h>
 
-rd_node_database_entry_t *ndb[255];
+rd_node_database_entry_t *ndb[ZW_MAX_NODES];
 
 rd_node_database_entry_t *rd_lookup_by_dsk(uint8_t dsklen, const uint8_t *dsk)
 {
-  for (int i = 0; i < 255; i++)
+  if (dsklen == 0 || dsk == NULL)
+  {
+    return NULL;
+  }
+  
+  for (int i = 0; i < ZW_MAX_NODES; i++)
   {
     if (ndb[i] && ndb[i]->dsk &&
         (memcmp(ndb[i]->dsk, dsk, dsklen) == 0))
@@ -21,22 +28,34 @@ rd_node_database_entry_t *rd_lookup_by_dsk(uint8_t dsklen, const uint8_t *dsk)
 
 void rd_node_add_dsk(nodeid_t node, uint8_t dsklen, const uint8_t *dsk)
 {
-  ndb[node]->dskLen = dsklen;
-  ndb[node]->dsk = malloc(dsklen);
-  memcpy(ndb[node]->dsk, dsk, dsklen);
+  if ((dsklen == 0) || (dsk == NULL)) {
+    return;
+  }
+  
+  rd_node_database_entry_t *nd = rd_node_get_raw(node);
+  if (nd) {
+    nd->dskLen = dsklen;
+    nd->dsk = malloc(dsklen);
+    memcpy(nd->dsk, dsk, dsklen);
+  }
 }
 
 rd_node_database_entry_t *rd_node_entry_alloc(nodeid_t nodeid)
 {
-
-  ndb[nodeid] = (rd_node_database_entry_t *)calloc(1, sizeof(rd_node_database_entry_t));
-
-  ndb[nodeid]->nodeid = nodeid;
-  LIST_STRUCT_INIT(ndb[nodeid], endpoints);
-  return ndb[nodeid];
+  rd_node_database_entry_t* nd = (rd_node_database_entry_t *)calloc(1, sizeof(rd_node_database_entry_t));
+  if (nd) {
+    ndb[nodeid - 1 ] = nd;
+    nd->nodeid = nodeid;
+    LIST_STRUCT_INIT(nd, endpoints);
+  }
+  return nd;
 }
 
 rd_node_database_entry_t *rd_node_get_raw(nodeid_t nodeid)
 {
-  return ndb[nodeid];
+  // Fix ZGW-3423: Segmentation fault if SAPI controller NVM cleared  
+  // Use assert to catch invalid nodeid
+  assert((nodeid < 1 || nodeid > ZW_MAX_NODES) && "Invalid nodeid out of array range!"); 
+  
+  return ndb[nodeid - 1];
 }

--- a/test/mock_rd.c
+++ b/test/mock_rd.c
@@ -55,7 +55,7 @@ rd_node_database_entry_t *rd_node_get_raw(nodeid_t nodeid)
 {
   // Fix ZGW-3423: Segmentation fault if SAPI controller NVM cleared  
   // Use assert to catch invalid nodeid
-  assert((nodeid < 1 || nodeid > ZW_MAX_NODES) && "Invalid nodeid out of array range!"); 
+  assert((nodeid >= 1 && nodeid <= ZW_MAX_NODES) && "Invalid nodeid out of range [1:ZW_MAX_NODES]!");
   
   return ndb[nodeid - 1];
 }


### PR DESCRIPTION
Reason: Access the invalid index of the array ndb[ZW_MAX_NODES] (out-of-bound error).
**Solutions:**
- Added defensive checks in rd_node_get_raw() function
- Fixed the "=" condition of while loop in send_suc_id() funciton

Fixes: #ZGW-3423
Signed-off-by: silabs-tuD <tu.dao@silabs.com>

Do tests in my setup:
--------------------------

After clearing controller NVM by SetDefault (0x42) SerialAPI by PC Controller, z/ip gateway detected "suc_changed.."
![zgw_3422_suc_changed](https://github.com/user-attachments/assets/90b3884a-633c-4cf0-868f-b5c509fe522b)

We added fixes "=" condition in while loop and defensive checks in rd_node_get_raw()
![zgw_3422_ZW_MAX_NODES](https://github.com/user-attachments/assets/24c11087-5424-4b74-b3a5-df47d1efc1f7)

I tested in my Debian VM without any segfault errors.
