### PR TITLE
Atomic flags

### DIFF
--- a/contiki/core/sys/process.c
+++ b/contiki/core/sys/process.c
@@ -46,6 +46,7 @@
 
 //#include <stdio.h>
 
+#include <stdatomic.h>
 #include "sys/process.h"
 #include "sys/arg.h"
 
@@ -75,7 +76,7 @@ static struct event_data events[PROCESS_CONF_NUMEVENTS];
 process_num_events_t process_maxevents;
 #endif
 
-static volatile unsigned char poll_requested;
+static atomic_uchar poll_requested;
 
 #define PROCESS_STATE_NONE        0
 #define PROCESS_STATE_RUNNING     1
@@ -119,7 +120,7 @@ process_start(struct process *p, const char *arg) CC_REENTRANT_ARG
   /* Put on the procs list.*/
   p->next = process_list;
   process_list = p;
-  p->state = PROCESS_STATE_RUNNING;
+  atomic_store_explicit(&p->state, PROCESS_STATE_RUNNING, memory_order_release);
   PT_INIT(&p->pt);
 
 #if ! CC_NO_VA_ARGS
@@ -149,7 +150,7 @@ exit_process(struct process *p, struct process *fromprocess) CC_REENTRANT_ARG
 
   if(process_is_running(p)) {
     /* Process was running */
-    p->state = PROCESS_STATE_NONE;
+    atomic_store_explicit(&p->state, PROCESS_STATE_NONE, memory_order_release);
 
     /*
      * Post a synchronous event to all processes to inform them that
@@ -189,27 +190,27 @@ call_process(struct process *p, process_event_t ev, process_data_t data) CC_REEN
   int ret;
 
 #if DEBUG
-  if(p->state == PROCESS_STATE_CALLED) {
+  if(atomic_load_explicit(&p->state, memory_order_acquire) == PROCESS_STATE_CALLED) {
 #if ! CC_NO_VA_ARGS
     printf("process: process '%s' called again with event %bu\n", PROCESS_NAME_STRING(p), ev);
 #endif
   }
 #endif /* DEBUG */
 
-  if((p->state & PROCESS_STATE_RUNNING) &&
+  if((atomic_load_explicit(&p->state, memory_order_acquire) & PROCESS_STATE_RUNNING) &&
      p->thread != NULL) {
 #if ! CC_NO_VA_ARGS
     PRINTF("process: calling process '%s' with event %bu\n", PROCESS_NAME_STRING(p), ev);
 #endif
     process_current = p;
-    p->state = PROCESS_STATE_CALLED;
+    atomic_store_explicit(&p->state, PROCESS_STATE_CALLED, memory_order_release);
     ret = p->thread(&p->pt, ev, data);
     if(ret == PT_EXITED ||
        ret == PT_ENDED ||
        ev == PROCESS_EVENT_EXIT) {
       exit_process(p, p);
     } else {
-      p->state = PROCESS_STATE_RUNNING;
+      atomic_store_explicit(&p->state, PROCESS_STATE_RUNNING, memory_order_release);
     }
   }
 #if 0
@@ -244,7 +245,7 @@ process_init(void)
 }
 /*---------------------------------------------------------------------------*/
 /*
- * Call each process' poll handler.
+ * Call each process' poll handler if and only if poll_requested flag was set.
  */
 /*---------------------------------------------------------------------------*/
 static void
@@ -252,11 +253,16 @@ do_poll(void) CC_REENTRANT_ARG
 {
   struct process *p;
 
-  poll_requested = 0;
+  // Always clear poll request flag; only continue if flag was previously set
+  char previous_poll_requested = atomic_exchange_explicit(&poll_requested, 0, memory_order_acq_rel);
+  if (previous_poll_requested == 0) {
+    return;
+  }
+
   /* Call the processes that needs to be polled. */
   for(p = process_list; p != NULL; p = p->next) {
     if(p->needspoll) {
-      p->state = PROCESS_STATE_RUNNING;
+      atomic_store_explicit(&p->state, PROCESS_STATE_RUNNING, memory_order_release);
       p->needspoll = 0;
       call_process(p, PROCESS_EVENT_POLL, NULL);
     }
@@ -304,9 +310,7 @@ do_event(void) CC_REENTRANT_ARG
 
 	/* If we have been requested to poll a process, we do this in
 	   between processing the broadcast event. */
-	if(poll_requested) {
-	  do_poll();
-	}
+	do_poll();
 	call_process(p, ev, data);
       }
     } else {
@@ -315,7 +319,7 @@ do_event(void) CC_REENTRANT_ARG
       /* If the event was an INIT event, we should also update the
 	 state of the process. */
       if(ev == PROCESS_EVENT_INIT) {
-	receiver->state = PROCESS_STATE_RUNNING;
+        atomic_store_explicit(&p->state, PROCESS_STATE_RUNNING, memory_order_release);
       }
 
       /* Make sure that the process actually is running. */
@@ -328,20 +332,18 @@ int
 process_run(void)
 {
   /* Process poll events. */
-  if(poll_requested) {
-    do_poll();
-  }
+  do_poll();
 
   /* Process one event from the queue */
   do_event();
 
-  return nevents + poll_requested;
+  return nevents + atomic_load_explicit(&poll_requested, memory_order_acquire);
 }
 /*---------------------------------------------------------------------------*/
 int
 process_nevents(void)
 {
-  return nevents + poll_requested;
+  return nevents + atomic_load_explicit(&poll_requested, memory_order_acquire);
 }
 /*---------------------------------------------------------------------------*/
 int
@@ -405,10 +407,11 @@ void
 process_poll(struct process *p) CC_REENTRANT_ARG
 {
   if(p != NULL) {
-    if(p->state == PROCESS_STATE_RUNNING ||
-       p->state == PROCESS_STATE_CALLED) {
+    char running_state = atomic_load_explicit(&p->state, memory_order_acquire);
+    if(running_state == PROCESS_STATE_RUNNING ||
+       running_state == PROCESS_STATE_CALLED) {
       p->needspoll = 1;
-      poll_requested = 1;
+      atomic_store_explicit(&poll_requested, 1, memory_order_release);
     }
   }
 }
@@ -416,5 +419,5 @@ process_poll(struct process *p) CC_REENTRANT_ARG
 int
 process_is_running(struct process *p) CC_REENTRANT_ARG
 {
-  return p->state != PROCESS_STATE_NONE;
+  return atomic_load_explicit(&p->state, memory_order_acquire) != PROCESS_STATE_NONE;
 }

--- a/contiki/core/sys/process.c
+++ b/contiki/core/sys/process.c
@@ -319,7 +319,8 @@ do_event(void) CC_REENTRANT_ARG
       /* If the event was an INIT event, we should also update the
 	 state of the process. */
       if(ev == PROCESS_EVENT_INIT) {
-        atomic_store_explicit(&p->state, PROCESS_STATE_RUNNING, memory_order_release);
+        atomic_store_explicit(&receiver->state, PROCESS_STATE_RUNNING, memory_order_release);
+
       }
 
       /* Make sure that the process actually is running. */

--- a/contiki/core/sys/process.c
+++ b/contiki/core/sys/process.c
@@ -261,9 +261,9 @@ do_poll(void) CC_REENTRANT_ARG
 
   /* Call the processes that needs to be polled. */
   for(p = process_list; p != NULL; p = p->next) {
-    if(p->needspoll) {
+    if(p->needspoll) { // Read after atomic exchange of `poll_requested`
       atomic_store_explicit(&p->state, PROCESS_STATE_RUNNING, memory_order_release);
-      p->needspoll = 0;
+      p->needspoll = 0; // Happens after atomic exchange of `poll_requested`
       call_process(p, PROCESS_EVENT_POLL, NULL);
     }
   }
@@ -411,7 +411,7 @@ process_poll(struct process *p) CC_REENTRANT_ARG
     char running_state = atomic_load_explicit(&p->state, memory_order_acquire);
     if(running_state == PROCESS_STATE_RUNNING ||
        running_state == PROCESS_STATE_CALLED) {
-      p->needspoll = 1;
+      p->needspoll = 1; // Happens before atomic store of `poll_requested`
       atomic_store_explicit(&poll_requested, 1, memory_order_release);
     }
   }

--- a/contiki/core/sys/process.h
+++ b/contiki/core/sys/process.h
@@ -324,7 +324,7 @@ struct process {
 #endif
   PT_THREAD((* thread)(struct pt *, process_event_t, process_data_t));
   struct pt pt;
-  atomic_char state;
+  atomic_uchar state;
   unsigned char needspoll;
 };
 

--- a/contiki/core/sys/process.h
+++ b/contiki/core/sys/process.h
@@ -54,6 +54,7 @@
 #ifndef __PROCESS_H__
 #define __PROCESS_H__
 
+#include <stdatomic.h>
 #include "sys/pt.h"
 #include "sys/cc.h"
 
@@ -323,7 +324,8 @@ struct process {
 #endif
   PT_THREAD((* thread)(struct pt *, process_event_t, process_data_t));
   struct pt pt;
-  unsigned char state, needspoll;
+  atomic_char state;
+  unsigned char needspoll;
 };
 
 /**

--- a/libzwaveip/libzwaveip/libzw_log.c
+++ b/libzwaveip/libzwaveip/libzw_log.c
@@ -16,6 +16,7 @@
 
 #include "libzw_log.h"
 
+#include <stdatomic.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
@@ -78,8 +79,8 @@ static __thread char my_thread_name[30];
 static pthread_mutex_t log_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int thread_count = 0;
 static const char *severity_names[LOGLVL_NONE];
-static volatile log_severity_t log_filter_level = LOGLVL_TRACE;
-static volatile log_severity_t log_ui_message_level = LOGLVL_WARN;
+static atomic_int log_filter_level = (int)LOGLVL_TRACE;
+static atomic_int log_ui_message_level = (int)LOGLVL_WARN;
 static FILE *log_file = NULL;
 static bool initialized = false;
 
@@ -129,22 +130,12 @@ bool libzw_log_init(const char *path) {
 
 log_severity_t libzw_log_set_filter_level(log_severity_t level)
 {
-  pthread_mutex_lock(&log_mutex);
-  log_severity_t old = log_filter_level;
-  log_filter_level = level;
-  pthread_mutex_unlock(&log_mutex);
-
-  return old;
+  return atomic_exchange_explicit(&log_filter_level, (int)level, memory_order_relaxed);
 }
 
 log_severity_t libzw_log_set_ui_message_level(log_severity_t level)
 {
-  pthread_mutex_lock(&log_mutex);
-  log_severity_t old = log_ui_message_level;
-  log_ui_message_level = level;
-  pthread_mutex_unlock(&log_mutex);
-
-  return old;
+  return atomic_exchange_explicit(&log_ui_message_level, (int)level, memory_order_relaxed);
 }
 
 bool libzw_log_check_severity(log_severity_t severity)
@@ -194,10 +185,7 @@ void libzw_log(log_severity_t severity, const char *file, uint32_t line, const c
       fflush(log_file);
       pthread_mutex_unlock(&log_mutex);
 
-      /* Ideally this section should also be protected by log_mutex (or another
-       * mutex), but since they can potentially be redefined to something that
-       * does not return quickly it's left unprotected for now. */
-      if (severity >= log_ui_message_level) {
+      if (severity >= (log_severity_t)atomic_load_explicit(&log_ui_message_level, memory_order_relaxed)) {
         if (severity >= LOGLVL_WARN) {
           UI_MSG_ERR("%s\n", buf);
         } else {


### PR DESCRIPTION
**Overview**

Zipgateway has a few instances of a perverse (anti-)pattern of using `volatile` variables to synchronize operations and data between threads. There is a common misconception (especially before C11) that variables marked with the keyword `volatile` are an appropriate tool for the job. These variables should instead be `atomic`, which incorporates memory barriers behind the scenes for inter-thread synchronization, memory ordering, and/or atomicity. This misunderstanding is common enough that it is explicitly called out in respected documentation on both keywords as shown below.


**Volatile**:

> Note that volatile variables are not suitable for communication between threads; they do not offer atomicity, synchronization, or memory ordering. A read from a volatile variable that is modified by another thread without synchronization or concurrent modification from two unsynchronized threads is undefined behavior due to a data race.

https://en.cppreference.com/w/c/language/volatile.html


**Atomic**:

> The library type sig_atomic_t does not provide inter-thread synchronization or memory ordering, only atomicity.
> 
> The volatile types do not provide inter-thread synchronization, memory ordering, or atomicity. 
> 

https://en.cppreference.com/w/c/language/atomic.html


**Process.c**

This file shares data between threads using both a global variable `poll_requested` and a struct member `state` within `struct process`. This both tracks state and coordinates operations related to requesting polling, and signalling that polling is complete. These variables were made `atomic` to ensure that threads all see a consistent state of this data. The memory ordering of acquire-release further coordinates the surrounding operations. All threads will agree that anything ordered before a release happens before the release. All threads will agree that anything ordered after an acquire happens after the acquire. No such guarantee was given in the prior version when the variables were merely `volatile`.

The `needspoll` member variable is synchronized by the acquire-release operations around it. No further changes are needed to protect this given the current usage pattern.

The `do_poll()` function was updated to combine both the read and write into a single atomic operation using `atomic_exchange_explicit()`. This function now checks if polling is required, clears the flag, and performs the polling (only if requested) all together. There were only two usages, and both fit this pattern. It also alleviates callers from worrying about the low-level details of coordinating their check with the other operations. It is now easier to use correctly.


**libzw_log.c**

The log level flags were updated to be atomic as well, which removed the need for locking. Atomic operations synchronize the value between threads, so no lock is needed for that. The set/swap operation is also provided as a single atomic function call with `atomic_exchange_explicit()`. This simplifies the code and reduces contention for the lock. There is also a beneficial knock-on effect in that the severity comparison can now be properly protected as well. A comment was removed regarding protecting that read with a lock.

Relaxed memory ordering was used in this case. These values are set at the beginning of the program lifetime by reading a configuration value. There does not appear to be any program logic that relies upon coordinating when this value is set compared to other operations the program executes. As such, the minimal ordering requirement is chosen here to reduce the performance cost as much as possible.