### PR TITLE
fix: widen ZW_Abort_SendRequest nodeid argument

### DIFF
--- a/src/transport/ZW_SendRequest.c
+++ b/src/transport/ZW_SendRequest.c
@@ -131,7 +131,7 @@ fail:
   return FALSE;
 }
 
-void ZW_Abort_SendRequest(uint8_t n)
+void ZW_Abort_SendRequest(nodeid_t n)
 {
 //  DBG_PRINTF("--------------- Inside ZW_Abort_SendRequest()\n");
   send_request_state_t* s;

--- a/src/transport/ZW_SendRequest.c
+++ b/src/transport/ZW_SendRequest.c
@@ -192,3 +192,33 @@ ZW_SendRequest_init()
   memb_init(&reqs);
   list_init(reqs_list);
 }
+
+#ifdef UNIT_TEST
+/* Test seams.
+ * Inject sessions into the file-static reqs_list
+ * without also mocking the contiki list/memb machinery, so we expose two
+ * narrow helpers used only by tests. */
+void *ZW_SendRequest_inject_waiting(nodeid_t snode,
+                                    ZW_SendRequst_Callback_t callback,
+                                    void *user)
+{
+  send_request_state_t *s = memb_alloc(&reqs);
+  if (!s) return NULL;
+  s->state = REQ_WAITING;
+  s->param.snode = snode;
+  s->callback = callback;
+  s->user = user;
+  s->timeout = 0;
+  s->round_trip_start = 0;
+  list_add(reqs_list, s);
+  return s;
+}
+
+int ZW_SendRequest_pending_count(void)
+{
+  int count = 0;
+  send_request_state_t *s;
+  for (s = list_head(reqs_list); s; s = list_item_next(s)) count++;
+  return count;
+}
+#endif /* UNIT_TEST */

--- a/src/transport/ZW_SendRequest.h
+++ b/src/transport/ZW_SendRequest.h
@@ -75,7 +75,7 @@ void ZW_SendRequest_init();
  * Abort send request for particular nodeid.
  * This command is used when removing the node. All pending Send Requests to that node need to be aborted.
  */
-void ZW_Abort_SendRequest(uint8_t nodeid);
+void ZW_Abort_SendRequest(nodeid_t nodeid);
 
 /**
  * @}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,8 @@ add_subdirectory(multicast_tlv)
 
 add_subdirectory(test_multicast_auto)
 
+add_subdirectory(zw_abort_sendrequest)
+
 add_subdirectory(CC_fw_upd)
 
 add_executable(eeprom-printer ${CMAKE_SOURCE_DIR}/test/eeprom-printer.c)

--- a/test/zw_abort_sendrequest/CMakeLists.txt
+++ b/test/zw_abort_sendrequest/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_definitions(-DUNIT_TEST)
+
+add_unity_test(NAME test_zw_abort_sendrequest
+  FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_zw_abort_sendrequest.c
+    ${CMAKE_SOURCE_DIR}/src/transport/ZW_SendRequest.c
+    ${CMAKE_SOURCE_DIR}/contiki/core/lib/list.c
+    ${CMAKE_SOURCE_DIR}/contiki/core/lib/memb.c
+)

--- a/test/zw_abort_sendrequest/test_zw_abort_sendrequest.c
+++ b/test/zw_abort_sendrequest/test_zw_abort_sendrequest.c
@@ -1,0 +1,120 @@
+/* Copyright Silicon Laboratories Inc.
+ *
+ */
+
+#include <string.h>
+#include <stdint.h>
+
+#include "contiki/core/sys/ctimer.h"
+#include "contiki/core/sys/clock.h"
+
+#include "unity.h"
+
+#include "ZW_SendRequest.h"
+#include "ZW_SendDataAppl.h"
+#include "ZW_transport_api.h"
+
+/*
+ * UNIT_TEST seams provided by ZW_SendRequest.c
+ */
+void *ZW_SendRequest_inject_waiting(nodeid_t snode,
+                                    ZW_SendRequst_Callback_t callback,
+                                    void *user);
+int   ZW_SendRequest_pending_count(void);
+
+void ctimer_set(struct ctimer *c, clock_time_t t, void (*f)(void *), void *ptr)
+{ (void)c; (void)t; (void)f; (void)ptr; }
+void ctimer_stop(struct ctimer *c) { (void)c; }
+clock_time_t clock_time(void) { return 0; }
+
+/* ZW_Abort_SendRequest does not call ZW_SendDataAppl, ts_param_make_reply,
+ * or ts_param_cmp.  The symbols must still resolve at link time because
+ * ZW_SendRequest() and SendRequest_ApplicationCommandHandler() (in the
+ * same translation unit) reference them. */
+uint8_t ZW_SendDataAppl(ts_param_t *p, const void *pData, uint16_t dataLength,
+                        ZW_SendDataAppl_Callback_t callback, void *user)
+{
+  (void)p; (void)pData; (void)dataLength; (void)callback; (void)user;
+  return 0;
+}
+
+void ts_param_make_reply(ts_param_t *dst, const ts_param_t *src)
+{
+  (void)dst; (void)src;
+}
+
+uint8_t ts_param_cmp(ts_param_t *a1, const ts_param_t *a2)
+{
+  (void)a1; (void)a2; return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* Test bookkeeping                                                    */
+/* ------------------------------------------------------------------ */
+typedef struct {
+  int     called;
+  uint8_t status;
+  void   *user;
+} cb_record_t;
+
+static int test_callback(BYTE txStatus, BYTE rxStatus,
+                         ZW_APPLICATION_TX_BUFFER *pCmd, WORD cmdLength,
+                         void *user)
+{
+  (void)rxStatus; (void)pCmd; (void)cmdLength;
+  cb_record_t *r = (cb_record_t *)user;
+  r->called++;
+  r->status = txStatus;
+  r->user   = user;
+  return 0;
+}
+
+static cb_record_t cb_lr;
+static cb_record_t cb_classic;
+
+void setUp(void)
+{
+  memset(&cb_lr, 0, sizeof(cb_lr));
+  memset(&cb_classic, 0, sizeof(cb_classic));
+  ZW_SendRequest_init();
+}
+
+void tearDown(void) {}
+
+/*
+ * LR snode (257) must match an abort issued with the same nodeid_t value.
+ * Pre-fix:  uint8_t param truncates 257 -> 1 -> no match -> no callback,
+ *           list size stays at 2.
+ * Post-fix: nodeid_t param matches, the LR session's callback fires with
+ *           TRANSMIT_COMPLETE_FAIL, and the list shrinks to 1.
+ */
+void test_abort_matches_lr_snode_without_truncation(void)
+{
+  nodeid_t lr_node = 257;
+  nodeid_t classic_node = 42;
+
+  void *s_lr = ZW_SendRequest_inject_waiting(lr_node, test_callback, &cb_lr);
+  void *s_classic = ZW_SendRequest_inject_waiting(classic_node, test_callback, &cb_classic);
+
+  TEST_ASSERT_NOT_NULL_MESSAGE(s_lr, "memb_alloc for LR session failed");
+
+  TEST_ASSERT_NOT_NULL_MESSAGE(s_classic, "memb_alloc for classic session failed");
+
+  TEST_ASSERT_EQUAL_INT_MESSAGE(2, ZW_SendRequest_pending_count(),
+                                "Pre-condition: two sessions queued");
+
+  ZW_Abort_SendRequest(lr_node);
+
+  TEST_ASSERT_EQUAL_INT_MESSAGE(1, cb_lr.called,
+    "LR (snode=257) session must be aborted exactly once. "
+    "Pre-fix: uint8_t truncates 257 -> 1, no match, callback never fires.");
+
+  TEST_ASSERT_EQUAL_UINT8_MESSAGE(TRANSMIT_COMPLETE_FAIL, cb_lr.status,
+    "Aborted session callback must receive TRANSMIT_COMPLETE_FAIL");
+
+  TEST_ASSERT_EQUAL_INT_MESSAGE(0, cb_classic.called,
+    "Classic (snode=42) session must NOT be aborted by ZW_Abort_SendRequest(257)");
+
+  TEST_ASSERT_EQUAL_INT_MESSAGE(1, ZW_SendRequest_pending_count(),
+    "Exactly one session must remain in reqs_list after the LR abort");
+}


### PR DESCRIPTION
`ZW_Abort_SendRequest(uint8_t)` was silently masking LR node IDs to their low byte, so any in-flight `REQ_WAITING` session for a node with `id >= 256` is never aborted and instead drains via the `request_timeout`. The caller (`rd_remove_node`) already passes a `nodeid_t`, so the bug is purely at the parameter-type boundary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small type-widening fix to avoid truncating Long Range node IDs, plus unit-test-only helper code guarded by `UNIT_TEST`. Main risk is limited to compile-time fallout for any out-of-tree callers still passing/expecting `uint8_t`.
> 
> **Overview**
> Fixes `ZW_Abort_SendRequest` to accept `nodeid_t` (instead of `uint8_t`), preventing truncation of Long Range node IDs (>=256) so in-flight `REQ_WAITING` sessions can be aborted immediately rather than timing out.
> 
> Adds a focused Unity regression test (`test_zw_abort_sendrequest`) and `UNIT_TEST`-guarded seams in `ZW_SendRequest.c` to inject pending sessions and assert the pending request count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2277b5a9071783dd98cbab326f9957d6fe541e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->