### PR TITLE
Ignore

### DIFF
--- a/src/serialapi/Serialapi.c
+++ b/src/serialapi/Serialapi.c
@@ -243,9 +243,9 @@ BYTE SupportsSerialAPISetup_func(BYTE subcmd)
                    "beyond 1st byte of Extended Z-Wave API Setup Supported Sub"
                    "Commands bitmask, which is not supported.\n", subcmd);
     } else if (subcmd > 8) {
-      return (is_bit_num_set_in_byte(subcmd - 8, capabilities.supported_serialapi_bitmask[2]));
+      return (is_bit_num_set_in_byte(subcmd - 9, capabilities.supported_serialapi_bitmask[2]));
     } else if (subcmd > 0) {
-      return (is_bit_num_set_in_byte(subcmd ,capabilities.supported_serialapi_bitmask[1]));
+      return (is_bit_num_set_in_byte(subcmd - 1,capabilities.supported_serialapi_bitmask[1]));
     }
   } else { // Check the bitflag as only one bit is set
     return (capabilities.supported_serialapi_bitmask[0] & subcmd);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes capability-gating logic for `FUNC_ID_SERIALAPI_SETUP`, which can enable/disable features (e.g., Long Range) depending on firmware-reported bitmasks.
> 
> **Overview**
> Corrects the bit position math in `SupportsSerialAPISetup_func()` so extended `SerialAPISetup` subcommand support is checked against the proper bit within `capabilities.supported_serialapi_bitmask`.
> 
> This fixes an off-by-one error for subcommands in the `1..8` and `9..16` ranges, which affects feature checks like `SerialAPI_SupportsLR()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f56044f05e6c9d9d554b8f74c0b232878d15c5cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->