### PR TITLE
Fix: Node List len is reported 0x00 when LR node is inlcuded

### DIFF
--- a/src/CC_NetworkManagement.c
+++ b/src/CC_NetworkManagement.c
@@ -2337,11 +2337,13 @@ LearnModeStatus(LEARN_INFO* inf)
  * will return 2. */
 uint16_t find_min_bitmask_len(uint8_t *buffer, uint16_t length)
 {
-    uint16_t i = 0;
-    while((i < length) && (buffer[i] != 0)) {
-      i++;
+    while (length > 0) {
+      if (buffer[length - 1] != 0) {
+        return length;
+      }
+      length--;
     }
-    return i;
+    return 0;
 }
 
 static uint16_t BuildFailedNodeListFrame(uint8_t* buffer, uint8_t seq)

--- a/src/CC_NetworkManagement.c
+++ b/src/CC_NetworkManagement.c
@@ -2377,7 +2377,7 @@ static uint16_t BuildFailedNodeListFrame(uint8_t* buffer, uint8_t seq)
   }
   /* Calculate minimum len of failed node list bitmask that needs to be sent
    * and not whole ZW_MAX_NODES/8 */ 
-  lr_len = find_min_bitmask_len(NODEMASK_GET_LR(nlist), MAX_NODEMASK_LENGTH);
+  lr_len = find_min_bitmask_len(NODEMASK_GET_LR(nlist), MAX_LR_NODEMASK_LENGTH);
 
   memcpy(&f->failedNodeListData1, nlist, MAX_CLASSIC_NODEMASK_LENGTH );
   f->extendedNodeidMSB = lr_len >> 8;


### PR DESCRIPTION
When an LR node is included, ZIPGW may send Node List Report / Failed Node List Report with LR node list length as 0x00 even though the Serial API returns a valid LR bitmask. This can hide LR nodes from downstream consumers.

Bug 1: find_min_bitmask_len() stops at first zero byte => This assumes non-zero bytes are contiguous from index 0, which is not valid for LR bitmasks.

Bug 2: Out-of-bounds read in BuildFailedNodeListFrame() => BuildFailedNodeListFrame() passed MAX_NODEMASK_LENGTH (500) instead of MAX_LR_NODEMASK_LENGTH (468) to find_min_bitmask_len():