### PR TITLE
Fix incorrect LBT threhold interpretation

### DIFF
--- a/Z-Wave/include/ZW_transport_api.h
+++ b/Z-Wave/include/ZW_transport_api.h
@@ -784,7 +784,8 @@ ZW_GetNodeIDMaskList(
 BYTE /*RET: TRUE if success or FALSE*/
 ZW_SetListenBeforeTalkThreshold(
   BYTE bChannel,                  /*IN: RF channel to set the threshold for */
-  BYTE bThreshold);               /*IN: Threshold to be added to RSSI limit */
+  int8_t bThreshold);             /*IN: Signed dBm CCA threshold (700/800);
+                                       legacy 34-78 index on 500-series */
 
 /**
  * Return Version on supplied Command Class if supported by protocol.

--- a/contiki/platform/linux/parse_config.c
+++ b/contiki/platform/linux/parse_config.c
@@ -391,16 +391,16 @@ void ConfigInit()
     else {
       cfg.rfregion = 0xFE;
     }
-    if (cfg.rfregion == 0x20 ) { //Japan 
-      cfg.zw_lbt = atoi(config_get_val("ZWLBT", "50"));
-      if ((cfg.zw_lbt < 34) || (cfg.zw_lbt > 78)) {
-        cfg.zw_lbt = 50;
-      }
+    /* ZWLBT is opt-in: only override the chip's regulatory region default when
+     * the operator explicitly sets it. The value is interpreted by chip type at
+     * apply time (signed dBm on 700/800, legacy 34-78 on 500-series), so it is
+     * stored verbatim here and validated in ZIP_Router. */
+    s = config_get_val("ZWLBT", NULL);
+    if (s != NULL) {
+      cfg.zw_lbt = atoi(s);
+      cfg.is_zw_lbt_set = 1;
     } else {
-      cfg.zw_lbt = atoi(config_get_val("ZWLBT", "64"));
-      if ((cfg.zw_lbt < 34) || (cfg.zw_lbt > 78)) {
-        cfg.zw_lbt = 64;
-      }
+      cfg.is_zw_lbt_set = 0;
     }
     endptr = NULL;
     int16_t max_lr_tx_powerlevel;

--- a/src/ZIP_Router.c
+++ b/src/ZIP_Router.c
@@ -953,6 +953,34 @@ ipv6_init()
 
 }
 
+bool zip_lbt_resolve_threshold(uint8_t chip_type, int value, uint8_t *out_byte)
+{
+  if (ZW_GECKO_CHIP_TYPE(chip_type)) {
+    /* SAPI specification, Release 1.9.0, S4.8.7:
+     * RSSI enconding values are signed dBm -128.. -1, 0..124.
+     *
+     * 700/800-series: A non-negative threshold sits above any real RSSI and
+     * would defeat LBT, so reject it. */
+
+    if ((value < -128) || (value >= 0)) {
+      return false;
+    }
+    *out_byte = (uint8_t)(int8_t)value;
+    return true;
+  }
+
+  if (chip_type == ZW_CHIP_TYPE) {
+    /* 500-series: legacy unsigned 34-78 index encoding. */
+    if ((value < 34) || (value > 78)) {
+      return false;
+    }
+    *out_byte = (uint8_t)value;
+    return true;
+  }
+
+  return false;
+}
+
 /*---------------------------------------------------------------------------*/
 /*--- ZIP Router --------*/
 static BOOL
@@ -1055,6 +1083,7 @@ ZIP_Router_Reset() CC_REENTRANT_ARG
 
   uint8_t rfregion;
   uint8_t channel_idx, max_idx;
+  uint8_t lbt_threshold;
   if(ZW_GECKO_CHIP_TYPE(chip_desc.my_chip_type)) {
     rfregion = ZW_RFRegionGet();
   } else {
@@ -1062,14 +1091,21 @@ ZIP_Router_Reset() CC_REENTRANT_ARG
   }
 
   rfregion = RF_REGION_CHECK(rfregion);
-  if(rfregion != 0xFE) { 
+  if(cfg.is_zw_lbt_set && (rfregion != 0xFE)) {
+    if (!zip_lbt_resolve_threshold(chip_desc.my_chip_type, cfg.zw_lbt,
+                                   &lbt_threshold)) {
+      WRN_PRINTF("Ignoring invalid ZWLBT value %d for chip type %d; keeping "
+                 "regulatory region default\n", cfg.zw_lbt,
+                 chip_desc.my_chip_type);
+      goto err;
+    }
     if ((rfregion == JP) || (rfregion == KR)) {
       max_idx = 3;
     } else {
       max_idx = 2;
     }
     for (channel_idx = 0; channel_idx < max_idx; channel_idx++) {
-      if(!ZW_SetListenBeforeTalkThreshold(channel_idx, cfg.zw_lbt)) {
+      if(!ZW_SetListenBeforeTalkThreshold(channel_idx, lbt_threshold)) {
         ERR_PRINTF("ERROR: Failed Setting ListenBeforeTalk Threshold to %d on "
              "channel: %d\n", cfg.zw_lbt, channel_idx);
         goto err;

--- a/src/ZIP_Router.h
+++ b/src/ZIP_Router.h
@@ -77,6 +77,20 @@ bool zgw_idle(void);
  */
 BYTE isClassicZWAddr(uip_ip6addr_t* ip);
 
+/** Resolve the LBT threshold wire byte for a given chip type.
+ *
+ * The ZWLBT byte has a different meaning per chip generation: signed dBm on
+ * 700/800-series (as per specification) and the legacy unsigned 34-78 index
+ * on 500-series.
+ *
+ * \param chip_type Chip type as reported by the Serial API.
+ * \param value     Configured ZWLBT value (signed dBm for Gecko, 34-78 for 500).
+ * \param out_byte  Receives the byte to send when the value is valid.
+ * \return true and sets *out_byte when valid for the chip; false to skip the
+ *         override (leaving the chip's regulatory region default in place).
+ */
+bool zip_lbt_resolve_threshold(uint8_t chip_type, int value, uint8_t *out_byte);
+
 /* TODO: Move ? */
 #ifdef __ASIX_C51__
 void Reset_Gateway(void) CC_REENTRANT_ARG;

--- a/src/doc/zipgateway.3
+++ b/src/doc/zipgateway.3
@@ -340,24 +340,30 @@ Hex encoded byte stream of ZIP Gateway device id. (Default: MAC address of ZIP G
 
 .TP
 .B ZWLBT
-Set the Lsten Before Talk Threshold anytime Z/IP Gateway resets the Z-Wave chip 
-The threshold controlles at what RSSI level a Z-Wave node will refuse to 
-transmit because of noise.
+Override the Listen Before Talk (LBT) threshold every time the Z/IP Gateway
+resets the Z-Wave chip. The threshold controls the RSSI level above which a
+Z-Wave node refuses to transmit because the channel is considered busy.
 
-The appropriate value range goes from 34(decimal) to 78(decimal) and each
-threshold step corresponds to a 1.5dB input power step. For instance, if a SAW 
-filter with an insertion loss of 3dB is inserted between the antenna 
-feed-point and the chip on a JP product, the threshold value should be set to 
-48(decimal) .
+This setting is optional. When ZWLBT is not present, the Z/IP Gateway leaves the
+chip's regulatory region default in place. Only set ZWLBT if you have a specific
+reason to override the regional default (for example, to compensate for a SAW
+filter insertion loss).
 
-See "4.3.3.11 ZW_SetListenBeforeTalkThreshold" section in 
-Z-Wave 500/700/800 Series Appl. Programmers Guide for more information
+The encoding of the value depends on the connected chip generation:
 
-NOTE: You should set ZWRFRegion to the frequency used for Z-wave 500 series
-to set LBT.
+500-series: legacy unsigned index in the range 34 to 78 (decimal), where each
+step corresponds to a 1.5 dB input power step.
 
-Default: 64 decimal (50 decimal for JP Frequency)
-Valid Range: 34 decimal to 78 decimal
+See "4.3.3.11 ZW_SetListenBeforeTalkThreshold" section in the Z-Wave Host API
+Specification for more information.
+
+Other series, including 700/800-series: signed dBm, matching the Z-Wave Host
+API Specification. The value must be negative (for example, -80 for JP, -65 for
+KR). Non-negative or out-of-range values are rejected and the chip default is
+kept.
+
+Default: unset (chip regulatory region default is used)
+Valid Range: negative dBm on 700/800-series, 34 to 78 decimal on 500-series
 
 .SH SEE ALSO
 .BR brctl (8),

--- a/src/serialapi/Serialapi.c
+++ b/src/serialapi/Serialapi.c
@@ -1738,10 +1738,10 @@ uint8_t ZW_SendSUCID(uint16_t node, uint8_t txOption,
  * RET:
  * 0 - failed, 1 - success
  */
-uint8_t ZW_SetListenBeforeTalkThreshold(uint8_t bChannel, uint8_t bThreshold) {
+uint8_t ZW_SetListenBeforeTalkThreshold(uint8_t bChannel, int8_t bThreshold) {
   idx = 0;
   buffer[idx++] = bChannel;
-  buffer[idx++] = bThreshold;
+  buffer[idx++] = (uint8_t)bThreshold;
   SendFrameWithResponse(FUNC_ID_ZW_SET_LISTEN_BEFORE_TALK_THRESHOLD, buffer, idx , buffer, 0);
   return buffer[IDX_DATA];
 }

--- a/src/zip_router_config.h
+++ b/src/zip_router_config.h
@@ -302,10 +302,20 @@ struct router_config {
 
   /** Configuration parameter ZWLBT in zipgateway.cfg.
    *
-   *  sets the LBT Threshold anytime ZIPGW resets the Z-Wave chip. 
+   *  Sets the LBT Threshold anytime ZIPGW resets the Z-Wave chip.
    *  ZW_SetListenBeforeTalkThreshold()
+   *
+   *  Signed value: dBm on 700/800-series, legacy 34-78 index on 500-series.
+   *  Only applied when is_zw_lbt_set is non-zero (ZWLBT present in the config).
    */
-  uint8_t zw_lbt;
+  int zw_lbt;
+
+  /** Mark if ZWLBT was explicitly set in zipgateway.cfg.
+   *
+   *  When unset, the gateway leaves the chip's regulatory region default in
+   *  place instead of overriding the LBT threshold.
+   */
+  int is_zw_lbt_set;
 
   /** Configuration parameter single_classic_temp_association in zipgateway.cfg
    *

--- a/test/ZIP_router/test_ZIP_router.c
+++ b/test/ZIP_router/test_ZIP_router.c
@@ -131,6 +131,55 @@ void test_ApplicationCommandHandlerZIP_WUN()
   TEST_ASSERT_EQUAL(mb_wakeup_event_args.node,0);
 }
 
+void test_zip_lbt_resolve_threshold()
+{
+  uint8_t wire = 0xAA;
+
+  /* 700/800 (Gecko): ZWLBT is signed dBm. */
+  wire = 0xAA;
+  TEST_ASSERT_TRUE(zip_lbt_resolve_threshold(7, -65, &wire));
+  TEST_ASSERT_EQUAL_HEX8(0xBF, wire);
+
+  wire = 0xAA;
+  TEST_ASSERT_TRUE(zip_lbt_resolve_threshold(8, -80, &wire));
+  TEST_ASSERT_EQUAL_HEX8(0xB0, wire);
+
+  /* Positive/out-of-range on Gecko is rejected (would defeat LBT). */
+  wire = 0xAA;
+  TEST_ASSERT_FALSE(zip_lbt_resolve_threshold(7, 64, &wire));
+  TEST_ASSERT_EQUAL_HEX8(0xAA, wire);
+
+  wire = 0xAA;
+  TEST_ASSERT_FALSE(zip_lbt_resolve_threshold(7, 0, &wire));
+  TEST_ASSERT_EQUAL_HEX8(0xAA, wire);
+
+  wire = 0xAA;
+  TEST_ASSERT_FALSE(zip_lbt_resolve_threshold(7, -129, &wire));
+  TEST_ASSERT_EQUAL_HEX8(0xAA, wire);
+
+  /* 500-series: ZWLBT keeps the legacy 34-78 unsigned encoding. */
+  wire = 0xAA;
+  TEST_ASSERT_TRUE(zip_lbt_resolve_threshold(5, 64, &wire));
+  TEST_ASSERT_EQUAL_HEX8(64, wire);
+
+  wire = 0xAA;
+  TEST_ASSERT_TRUE(zip_lbt_resolve_threshold(5, 50, &wire));
+  TEST_ASSERT_EQUAL_HEX8(50, wire);
+
+  wire = 0xAA;
+  TEST_ASSERT_FALSE(zip_lbt_resolve_threshold(5, 33, &wire));
+  TEST_ASSERT_EQUAL_HEX8(0xAA, wire);
+
+  wire = 0xAA;
+  TEST_ASSERT_FALSE(zip_lbt_resolve_threshold(5, 79, &wire));
+  TEST_ASSERT_EQUAL_HEX8(0xAA, wire);
+
+  /* Unknown chip type: skip the override entirely. */
+  wire = 0xAA;
+  TEST_ASSERT_FALSE(zip_lbt_resolve_threshold(0, -65, &wire));
+  TEST_ASSERT_EQUAL_HEX8(0xAA, wire);
+}
+
 static void test_is_linklayer_addr_zero()
 {
   uip_lladdr_t uip_lladdr; /* Mocked from uip6.c */

--- a/test/serialapi/test_serialapi.c
+++ b/test/serialapi/test_serialapi.c
@@ -10,8 +10,9 @@
 #define CHECKSUM 0xFF
 #define TEST_ZW_VERSION                                                        \
   0x7A, 0x65, 0x65, 0x77, 0x61, 0x76, 0x65, 0x72, 0x6F, 0x63, 0x6B, 0x73
+/* Among others, support Set LBT Threshold, that is byte 7, bit 3 set (0x0F)  */
 #define SUPPORTED_CMDS                                                         \
-  0xFF, 0x05, 0xFF, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0xFF, 0x0a, 0x0b,      \
+  0xFF, 0x05, 0xFF, 0x03, 0x04, 0x05, 0x06, 0x0F, 0x08, 0xFF, 0x0a, 0x0b,      \
       0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0xFF,  \
       0x18, 0x19, 0x1a, 0x1b, 0x1c
 #define SUPPORTED_API_CMDS                                                     \
@@ -520,6 +521,39 @@ void test_drops_insufficient_zw_set_learn_mode_frame() {
   TEST_ASSERT_FALSE(session.is_timeout);
   TEST_ASSERT_EQUAL(ACK, session.rx.data[0]);
   TEST_ASSERT_FALSE(is_cb_called);
+}
+
+void test_set_listen_before_talk_threshold_signed_dbm() {
+  void *Device_SetLBT(void *ptr) {
+    Device_ReceiveFrame((session_t *)ptr);
+    return NULL;
+  }
+
+  pthread_t device_loop;
+
+  /* Request frame on the wire:
+   * SOF, LEN, REQUEST, FUNC_ID, bChannel, bThreshold, CHECKSUM (7 bytes).
+   * Response frame: RES | FUNC_ID | TRUE. */
+  session_t session = {
+      .rx = {.size = 0x07},
+      .tx = {.data = {SOF, 0x04, RESPONSE,
+                      FUNC_ID_ZW_SET_LISTEN_BEFORE_TALK_THRESHOLD, TRUE,
+                      CHECKSUM},
+             .size = 0x06}};
+
+  TEST_ASSERT_FALSE(
+      pthread_create(&device_loop, NULL, Device_SetLBT, &session));
+
+  /* -65 dBm must reach the wire as 0xBF, not be mangled by an unsigned type. */
+  uint8_t ret = ZW_SetListenBeforeTalkThreshold(0, (int8_t)-65);
+
+  TEST_ASSERT_FALSE(pthread_join(device_loop, NULL));
+
+  TEST_ASSERT_EQUAL_HEX8(FUNC_ID_ZW_SET_LISTEN_BEFORE_TALK_THRESHOLD,
+                         session.rx.data[3]);
+  TEST_ASSERT_EQUAL_HEX8(0x00, session.rx.data[4]);
+  TEST_ASSERT_EQUAL_HEX8(0xBF, session.rx.data[5]);
+  TEST_ASSERT_EQUAL(TRUE, ret);
 }
 
 void test_drops_insufficient_application_update_frame() {


### PR DESCRIPTION
The Z/IP Gateway always pushed the legacy 500-series 34-78 LBT threshold to the Z-Wave chip on every reset. On 700/800-series modules that byte is read as a signed dBm CCA threshold, so a value like 64 becomes +64 dBm, above any real RSSI, which effectively disables LBT. This breaks regulatory compliance where LBT is mandated.

The Z-Wave Serial API specification, Section 4.8.7, Set Listen Before Talk Threshold Command, describes the LBT value as a 8-bit signed value.

Make the ZWLBT override opt-in and chip-aware:
  - Only override when ZWLBT is explicitly set, otherwise keep the chip's default.
  - Interpret ZWLBT as signed dBm on 700/800 and as the legacy 34-78 index on 500-series, rejecting values that cannot be valid for the chip.