### PR TITLE
fix: honor ZipAssociationLimit debconf setting on package install

### DIFF
--- a/files/scripts/postinst
+++ b/files/scripts/postinst
@@ -196,8 +196,9 @@ iface br-lan inet dhcp
 fi
 
 value=0
-db_input zipgateway/association_limit || true
-[ "Disabled" = "$RET" ] || value=1
+db_get zipgateway/association_limit
+[ "Enabled" = "$RET" ] && value=1
+sed -i "/ZipAssociationLimit*/d" $GW_CONFFILE
 echo ZipAssociationLimit=$value >> $GW_CONFFILE
 
 db_get zipgateway/restart_nw


### PR DESCRIPTION
The postinst script read the wrong debconf variable after db_input and appended ZipAssociationLimit on every install, so the experimental value was enabled by default and reinstallations added duplicate config lines.

Relates-to: ZWAVE_SDK-2064